### PR TITLE
implement command history navigation

### DIFF
--- a/command_history.py
+++ b/command_history.py
@@ -1,0 +1,44 @@
+from collections import deque
+
+MAX_HISTORY_SIZE = 10
+
+class CommandHistory:
+    def __init__(self):
+        self.history = deque(maxlen=MAX_HISTORY_SIZE)
+        self.cursor = -1
+
+    def add(self, command: str):
+        # Reset cursor
+        self.cursor = -1
+
+        # Avoid adding duplicate commands
+        if command == self.peek():
+            return
+
+        if len(self.history) == self.history.maxlen:
+            self.history.pop()
+        self.history.appendleft(command)
+
+    def scroll_up(self):
+        if len(self.history) == 0:
+            return ""
+
+        if self.cursor < len(self.history) - 1:
+            self.cursor += 1
+            return self.history[self.cursor]
+
+        return self.history[-1]
+
+    def scroll_down(self):
+        if len(self.history) == 0 or self.cursor <= 0:
+            self.cursor = max(-1, self.cursor - 1)
+            return ""
+
+        self.cursor -= 1
+        return self.history[self.cursor]
+
+    def peek(self):
+        if len(self.history) == 0:
+            return ""
+
+        return self.history[0]


### PR DESCRIPTION
This PR adds command history navigation functionality (#1) with the following features:
- pressing "up arrow" adds most recently executed command to the input line, going back in history until the bottom of the stack is reached
- pressing "down arrow" goes forward in history until reaching the top of the stack, after which an empty string is printed
- if the most recent command is equal to the command at the top of the stack, no command is added, in order to avoid duplicate commands
- the maximum history is easily configurable - if the max size is reached, older commands are dropped from the stack

@rrmn Please let me know if I've missed any established conventions or if you have any other feedback, cheers!